### PR TITLE
Fixed Issue #143 Workflow Trigger Bug

### DIFF
--- a/.github/workflows/youtube.yml
+++ b/.github/workflows/youtube.yml
@@ -2,7 +2,7 @@ name: YouTube Videos
 on:
   push:
   schedule:
-    - cron: '0 * * * *'
+  - cron: '30 0 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### As Described in the issue #143,
>Currently, the workflow triggers **every hour**, 

But as suggested by you, the best time it should trigger is half past 12 at midnight. I have made changes in the youtube.yml file.

There was a little bit of confusion, as your latest video described that the GitHub triggers every day at 12 at midnight but it triggers every hour, This has been mentioned and explained in issue #143 .

If this solves the issue, consider merging it, also up for any modification or other contribution....
Thanks 😊
